### PR TITLE
Add info on get_param option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ After running ```grunt cache-busting```, this file will look like this, and the 
 </html>
 ```
 
-Optionally, you can pass the `get_param` option to simply append a parameter to the path of the file. This is useful if you need to change the contents of a file, but not the filename.
+Optionally, you can pass the `get_param` option to simply append a query string parameter to the path of the file. This is useful if you need to change the contents of a file, but not the filename.
+
+*Note:  Some proxy servers do not re-request assets when a new query string is used.  If a significant portion of your users use proxy servers, you may want to change the filename instead of appending a query string.*
 
 ```javascript
 'cache-busting': {


### PR DESCRIPTION
Query strings are not effective at cache-busting for some proxy servers.  They are fine to use in most cases, but if you expect your users to be behind a proxy, query strings might not cut it.
See here: http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/
