### PR TITLE
Pulls/regex file replace

### DIFF
--- a/tasks/cache-busting.js
+++ b/tasks/cache-busting.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
 				src: this.data.replace,
 				overwrite: true,
 				replacements: [{
-					from: this.data.replacement,
+					from: new RegExp(this.data.replacement + "(\\?v=)?([a-z0-9]+)*"),
 					to: this.data.replacement + "?v=" + hash
 				}]
 			});


### PR DESCRIPTION
Adding regex for replacements of file names in templates. This addresses an issue where it would either append the hash value (in the case of get_param = true), or ignore (in the other case) the src string rather than replace the value.
