### PR TITLE
Rename the file synchronously

### DIFF
--- a/tasks/cache-busting.js
+++ b/tasks/cache-busting.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
 					fs.unlink(file);
 				})
 			}
-			fs.rename(this.data.file, outputFile);
+			fs.renameSync(this.data.file, outputFile);
 
 			gruntTextReplace.replace({
 				src: this.data.replace,


### PR DESCRIPTION
Without this, the rename doesn't necessarily complete before the end of the task, making successive task (such as zipping a folder in cluding this file) unreliable.
