### PR TITLE
Accept file name without extension. E.g. data-main tag via RequireJS

### DIFF
--- a/tasks/cache-busting.js
+++ b/tasks/cache-busting.js
@@ -33,12 +33,12 @@ module.exports = function (grunt) {
 				})
 			}
 			fs.rename(this.data.file, outputFile);
-
+			var from = replacementWithoutExtension + (replacementExtension ? "((\-?)(.+)*)" + replacementExtension : '');
 			gruntTextReplace.replace({
 				src: this.data.replace,
 				overwrite: true,
 				replacements: [{
-					from: new RegExp(replacementWithoutExtension + "((\-?)(.+)*)" + replacementExtension),
+					from: new RegExp(from),
 					to: replacementWithoutExtension + "-" + hash + replacementExtension
 				}]
 			});


### PR DESCRIPTION
This change supports file name without extension.
For example:
```
<script data-main="js/config" src="vendor/require.js"></script>
```
This would be busted to
```
<script data-main="js/config-HASH" src="vendor/require.js"></script>
```