### PR TITLE
File minimatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,30 @@ Will change the html above to this:
 </html>
 ```
 
+File supports minimatch, allowing several files to be hashed and replaced. If this option is specified the replacement parameter cannot be present.
+
+```javascript
+'cache-busting': {
+	all: {
+		replace: ['tmp/**/*.html'],
+		file: 'tmp/deploy/**/*.css'
+	}
+}
+```
+```html
+<html>
+<head>
+	<link rel="stylesheet" href="css/style.css?v=HASH-OF-FILE-CONTENTS" />
+
+	<script data-main="js/app/MainApp-HASH-OF-FILE-CONTENTS" src="js/vendors/requirejs/require.js"></script>
+</head>
+<body>
+
+</body>
+</html>
+```
+Will change the html above to this:
+
 
 ## API reference
 ### replace
@@ -108,7 +132,10 @@ It supports [minimatch paths](https://github.com/isaacs/minimatch).
 
 ### file
 *file* is the file which will be renamed to filename-HASH-OF-FILE-CONTENTS.ext. The hash is generated based on the file
-contents of this parameter.
+contents of this parameter. It supports [minimatch paths](https://github.com/isaacs/minimatch).
+
+### matchHashed
+*matchHashed* If true (or not present) usages of filename-OLD-HASH-OF-FILE-CONTENTS.ext will be replaced with filename-NEW-HASH-OF-FILE-CONTENTS.ext. If false only usages of filename.ext will be replaced.
 
 ## Credits
 This plugin is build on top of [grunt-text-replace](https://github.com/yoniholmes/grunt-text-replace/) and was inspired by [grunt-cache-bust](https://github.com/hollandben/grunt-cache-bust)

--- a/tasks/cache-busting.js
+++ b/tasks/cache-busting.js
@@ -6,43 +6,58 @@ module.exports = function (grunt) {
 		gruntTextReplace = require('grunt-text-replace/lib/grunt-text-replace');
 
 	grunt.registerMultiTask('cache-busting', 'Cache bust file and update references', function() {
-		var fileContents = grunt.file.read(this.data.file),
-			hash = crypto.createHash('md5').update(fileContents).digest("hex"),
-			outputDir = path.dirname(this.data.file),
-			fileExtension = path.extname(this.data.file),
-			replacementExtension = path.extname(this.data.replacement),
-			replacementWithoutExtension = this.data.replacement.slice(0, this.data.replacement.length - replacementExtension.length),
-			outputFile = outputDir + path.sep + replacementWithoutExtension + "-" + hash + fileExtension;
-
-		if (this.data.get_param){
-
-			gruntTextReplace.replace({
-				src: this.data.replace,
-				overwrite: true,
-				replacements: [{
-					from: new RegExp(this.data.replacement + "(\\?v=)?([a-z0-9]+)*"),
-					to: this.data.replacement + "?v=" + hash
-				}]
-			});
-
-		} else {
-			if (this.data.cleanup) {
-				var files = glob.sync(outputDir + path.sep + replacementWithoutExtension + "-*" + fileExtension);
-				files.forEach(function(file){
-					fs.unlink(file);
-				})
+		var filesToReplace = grunt.file.expand(this.data.file, 'isFile');
+		var hasReplacement = this.data.replacement !== undefined;
+		for (var i = 0; i < filesToReplace.length; i++) {
+			var replacement;
+			if (hasReplacement) {
+				replacement = this.data.replacement
+			} else {
+				replacement = path.basename(filesToReplace[i]);
 			}
-			fs.rename(this.data.file, outputFile);
-			var from = replacementWithoutExtension + (replacementExtension ? "((\-?)(.+)*)" + replacementExtension : '');
-			gruntTextReplace.replace({
-				src: this.data.replace,
-				overwrite: true,
-				replacements: [{
-					from: new RegExp(from),
-					to: replacementWithoutExtension + "-" + hash + replacementExtension
-				}]
-			});
+			var fileContents = grunt.file.read(filesToReplace[i]),
+				hash = crypto.createHash('md5').update(fileContents).digest("hex"),
+				outputDir = path.dirname(filesToReplace[i]),
+				fileExtension = path.extname(filesToReplace[i]),
+				replacementExtension = path.extname(replacement),
+				replacementWithoutExtension = replacement.slice(0, replacement.length - replacementExtension.length),
+				outputFile = outputDir + path.sep + replacementWithoutExtension + "-" + hash + fileExtension;
 
+			if (this.data.get_param){
+
+				gruntTextReplace.replace({
+					src: this.data.replace,
+					overwrite: true,
+					replacements: [{
+						from: new RegExp(replacement + "(\\?v=)?([a-z0-9]+)*"),
+						to: replacement + "?v=" + hash
+					}]
+				});
+
+			} else {
+				if (this.data.cleanup) {
+					var files = glob.sync(outputDir + path.sep + replacementWithoutExtension + "-*" + fileExtension);
+					files.forEach(function(file){
+						fs.unlink(file);
+					})
+				}
+				fs.rename(filesToReplace[i], outputFile);
+				var from;
+				if (this.data.matchHashed === undefined || this.data.matchHashed) {
+					from = replacementWithoutExtension + (replacementExtension ? "((\-?)(.+)*)" + replacementExtension : '');
+				} else {
+					from = replacementWithoutExtension + replacementExtension;
+				}
+				gruntTextReplace.replace({
+					src: this.data.replace,
+					overwrite: true,
+					replacements: [{
+						from: new RegExp(from),
+						to: replacementWithoutExtension + "-" + hash + replacementExtension
+					}]
+				});
+
+			}
 		}
 	});
 };


### PR DESCRIPTION
File can now be a minimatch expression. This allows minifying directories and updating other source files with their updated paths. This is useful for angular templateUrls, it allows one to cache bust all html files and update the js files which declare them.

I also added an option matchHashed. If match hashed is undefined or true we try to replace file-HASH.ext. Otherwise we only try to replace file.ext.

The documentation has also been updated.
